### PR TITLE
Complete item stats and localization module docs

### DIFF
--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -1,7 +1,7 @@
 # TeamSoda.Duckov.Core - 核心模块
 
 ## 概述
-TeamSoda.Duckov.Core 是《逃离鸭科夫》游戏的核心模块，包含了游戏的主要系统、角色控制、UI管理、关卡管理等核心功能。
+TeamSoda.Duckov.Core 是《逃离鸭科夫》游戏的核心模块，包含了游戏的主要系统、角色控制、UI 管理、关卡管理等核心功能。
 
 ## 核心类
 
@@ -9,178 +9,741 @@ TeamSoda.Duckov.Core 是《逃离鸭科夫》游戏的核心模块，包含了�
 游戏管理器，负责管理游戏的整体状态和各个子系统。
 
 #### 静态属性
-- `Instance` - 获取GameManager单例实例
-- `Paused` - 游戏是否暂停
-- `AudioManager` - 音频管理器
-- `UiInputManager` - UI输入管理器
-- `PauseMenu` - 暂停菜单
-- `DifficultyManager` - 难度管理器
-- `SceneLoader` - 场景加载器
-- `BlackScreen` - 黑屏控制器
-- `EventSystem` - 事件系统
-- `NightVision` - 夜视系统
-- `BloodFxOn` - 血液特效开关
-- `MainPlayerInput` - 主玩家输入
-- `ModManager` - Mod管理器
-- `NoteIndex` - 笔记索引
-- `AchievementManager` - 成就管理器
+- `Instance` - 获取 GameManager 单例实例。
+- `Paused` - 游戏是否暂停。
+- `AudioManager` - 当前音频管理器实例。
+- `UiInputManager` - UI 输入管理器。
+- `PauseMenu` - 暂停菜单。
+- `DifficultyManager` - 难度/规则管理器。
+- `SceneLoader` - 场景加载器。
+- `BlackScreen` - 黑屏控制器。
+- `EventSystem` - Unity 事件系统。
+- `NightVision` - 夜视后处理控制。
+- `BloodFxOn` - 是否启用流血特效（来自 GameMetaData）。
+- `MainPlayerInput` - 当前主玩家输入组件。
+- `ModManager` - Mod 管理器实例。
+- `NoteIndex` - 笔记索引管理器。
+- `AchievementManager` - 成就管理器。
 
-#### 方法
-- `TimeTravelDetected()` - 检测到时间穿越
+#### 静态字段
+- `newBoot` - 标记当前是否为新启动流程。
+
+#### 静态方法
+- `TimeTravelDetected()` - 在检测到时间错误/回档时触发处理流程。
+
+---
 
 ### CharacterMainControl
-角色主控制器，管理角色的移动、战斗、物品使用等核心功能。
+角色主控制器，管理角色移动、战斗、技能、交互、物品与 Buff 等核心功能。
 
 #### 公有静态属性
-- `Main` - 获取主角色实例 (public static)
+- `Main` - 获取当前关卡主角色实例，若关卡尚未初始化则返回 `null`。
 
-#### 公有属性
-- `AudioVoiceType` - 音频声音类型 (public get/set)
-- `FootStepMaterialType` - 脚步声材质类型 (public get/set)
-- `Team` - 角色队伍 (public get)
-- `CharacterItem` - 角色物品 (public get)
-- `CurrentHoldItemAgent` - 当前手持物品代理 (public get)
-- `Hidden` - 是否隐藏 (public get)
-- `CurrentUsingAimSocket` - 当前使用的瞄准插槽 (public get)
-- `RightHandSocket` - 右手插槽 (public get)
-- `CurrentAimDirection` - 当前瞄准方向 (public get)
-- `CurrentMoveDirection` - 当前移动方向 (public get)
-- `AnimationMoveSpeedValue` - 动画移动速度值 (public get)
-- `AnimationLocalMoveDirectionValue` - 动画本地移动方向值 (public get)
-- `Running` - 是否在奔跑 (public get)
-- `IsOnGround` - 是否在地面上 (public get)
-- `Velocity` - 速度 (public get)
-- `ThermalOn` - 热成像是否开启 (public get)
-- `IsInAdsInput` - 是否在瞄准输入 (public get)
-- `AdsValue` - 瞄准值 (public get)
-- `AimType` - 瞄准类型 (public get)
-- `CurrentAction` - 当前动作 (public get)
-- `Health` - 生命值 (public get)
-- `MoveInput` - 移动输入 (public get)
-- `EquipmentController` - 装备控制器 (public get)
-- `Dashing` - 是否在冲刺 (public get)
+#### 公有静态事件与回调
+- `OnMainCharacterStartUseItem` - 主角色开始使用物品时触发（事件）。
+- `OnMainCharacterInventoryChangedEvent` - 主角色背包内容变化时触发，提供角色、背包与槽位哈希（委托类型：`Action<CharacterMainControl, Inventory, int>`）。
+- `OnMainCharacterSlotContentChangedEvent` - 主角色具体槽位内容变化时触发，提供角色与槽位引用（委托类型：`Action<CharacterMainControl, Slot>`）。
+- `OnMainCharacterChangeHoldItemAgentEvent` - 主角色手持物品代理发生变化时触发（`Action<CharacterMainControl, DuckovItemAgent>`）。
 
 #### 公有事件
-- `OnTeamChanged` - 队伍改变事件 (public event)
-- `OnSetPositionEvent` - 设置位置事件 (public event)
-- `BeforeCharacterSpawnLootOnDead` - 角色死亡前生成战利品事件 (public event)
-- `OnActionStartEvent` - 动作开始事件 (public event)
-- `OnActionProgressFinishEvent` - 动作进度完成事件 (public event)
-- `OnHoldAgentChanged` - 手持代理改变事件 (public event)
-- `OnShootEvent` - 射击事件 (public event)
-- `TryCatchFishInputEvent` - 尝试抓鱼输入事件 (public event)
-- `OnAttackEvent` - 攻击事件 (public event)
-- `OnSkillStartReleaseEvent` - 技能开始释放事件 (public event)
+- `OnTeamChanged` - 队伍变更回调。
+- `OnSetPositionEvent` - 角色位置被外部设置时触发。
+- `BeforeCharacterSpawnLootOnDead` - 角色生成掉落物前触发，可修改伤害数据。
+- `OnActionStartEvent` - 新动作开始执行时通知。
+- `OnActionProgressFinishEvent` - 动作进度完成时通知。
+- `OnHoldAgentChanged` - 当前手持物品代理变化时通知。
+- `OnShootEvent` - 触发射击动作时回调。
+- `TryCatchFishInputEvent` - 钓鱼尝试收杆输入时回调。
+- `OnAttackEvent` - 近战攻击触发事件。
+- `OnSkillStartReleaseEvent` - 技能开始释放时通知。
 
-#### 公有静态事件
-- `OnMainCharacterStartUseItem` - 主角色开始使用物品事件 (public static event)
-- `OnMainCharacterInventoryChangedEvent` - 主角色背包改变事件 (public static event)
-- `OnMainCharacterSlotContentChangedEvent` - 主角色插槽内容改变事件 (public static event)
-- `OnMainCharacterChangeHoldItemAgentEvent` - 主角色改变手持物品代理事件 (public static event)
+#### 公有字段
+- `characterPreset` - 角色随机预设数据。
+- `movementControl` - 角色移动控制组件。
+- `agentHolder` - 物品代理持有器。
+- `carryAction` - 搬运动作处理组件。
+- `characterModel` - 角色模型引用。
+- `deadLootBoxPrefab` - 角色死亡后生成的战利品箱预制体。
+- `modelRoot` - 模型根节点变换。
+- `buffResist` - 角色具备免疫的 Buff 标签列表。
+- `reloadAction` - 装填动作控制。
+- `skillAction` - 角色技能动作控制。
+- `useItemAction` - 使用物品动作控制。
+- `interactAction` - 交互动作控制。
+- `dashAction` - 冲刺动作控制。
+- `attackAction` - 攻击动作控制。
+- `mainDamageReceiver` - 主体伤害接收组件。
+- `weightThreshold_Light` - 轻负重阈值 (0.25)。
+- `weightThreshold_Heavy` - 重负重阈值 (0.5)。
+- `weightThreshold_superWeight` - 超重阈值 (0.75)。
+
+#### 公有属性（基础引用与状态）
+- `AudioVoiceType` - 当前语音类型（设置时会同步给 AudioManager）。
+- `FootStepMaterialType` - 当前脚步声材质类型。
+- `Team` - 当前所属队伍。
+- `CharacterItem` - 绑定的角色物品条目。
+- `CurrentHoldItemAgent` - 当前手持物品代理。
+- `Hidden` - 是否处于隐藏状态。
+- `CurrentUsingAimSocket` - 当前用于瞄准的插槽变换。
+- `RightHandSocket` - 角色右手插槽变换。
+- `CurrentAimDirection` - 当前角色朝向/瞄准方向。
+- `CurrentMoveDirection` - 当前移动方向（XZ 平面）。
+- `AnimationMoveSpeedValue` - 动画驱动的移动速度参数。
+- `AnimationLocalMoveDirectionValue` - 动画驱动的本地移动方向参数。
+- `Running` - 是否处于奔跑状态。
+- `IsOnGround` - 是否在地面上。
+- `Velocity` - 当前刚体速度。
+- `ThermalOn` - 是否启用热成像。
+- `IsInAdsInput` - 是否接收到瞄准（ADS）输入。
+- `AdsValue` - 当前瞄准插值数值。
+- `AimType` - 当前瞄准类型。
+- `NeedToSearchTarget` - 触屏操作下是否需要自动寻找目标。
+- `CurrentAction` - 当前执行的角色动作。
+- `Health` - 角色生命组件。
+- `MoveInput` - 移动输入向量。
+- `EquipmentController` - 装备控制器。
+- `Dashing` - 是否正在冲刺。
+- `IsMainCharacter` - 是否为 LevelManager 主角色。
+
+#### 公有属性（数值与能力）
+- `CharacterWalkSpeed` - 当前步行速度。
+- `AdsWalkSpeedMultiplier` - 瞄准时移动速度倍率。
+- `CharacterOriginWalkSpeed` - 角色基础移动速度。
+- `CharacterRunSpeed` - 实际奔跑速度（包含装备影响）。
+- `StormProtection` - 风暴伤害防护。
+- `WaterEnergyRecoverMultiplier` - 饮水体力恢复倍率。
+- `GunDistanceMultiplier` - 枪械射程倍率。
+- `CharacterMoveability` - 移动能力系数。
+- `CharacterRunAcc` - 奔跑加速度。
+- `CharacterTurnSpeed` - 转向速度。
+- `CharacterAimTurnSpeed` - 瞄准时转向速度。
+- `DashSpeed` - 冲刺速度。
+- `PetCapcity` - 宠物数量上限。
+- `DashCanControl` - 冲刺时是否可操作方向。
+- `MaxStamina` - 最大耐力值。
+- `CurrentStamina` - 当前耐力值。
+- `StaminaDrainRate` - 耐力消耗速率。
+- `StaminaRecoverRate` - 耐力恢复速率。
+- `StaminaRecoverTime` - 恢复耐力需要的时间。
+- `CharacterWalkAcc` - 步行加速度。
+- `VisableDistanceFactor` - 可视距离系数。
+- `MaxWeight` - 最大负重。
+- `FoodGain` - 食物收益。
+- `HealGain` - 治疗收益。
+- `MaxEnergy` - 最大精力。
+- `EnergyCostPerMin` - 每分钟精力消耗。
+- `CurrentEnergy` - 当前精力值。
+- `MaxWater` - 最大水分值。
+- `WaterCostPerMin` - 每分钟水分消耗。
+- `CurrentWater` - 当前水分值。
+- `NightVisionAbility` - 夜视能力。
+- `NightVisionType` - 夜视类型。
+- `HearingAbility` - 听力能力值。
+- `SoundVisable` - 声音可视化强度。
+- `ViewAngle` - 视野角度。
+- `ViewDistance` - 视距。
+- `SenseRange` - 感知范围。
+- `MeleeDamageMultiplier` - 近战伤害倍率。
+- `MeleeCritRateGain` - 近战暴击率增益。
+- `MeleeCritDamageGain` - 近战暴击伤害增益。
+- `GunDamageMultiplier` - 枪械伤害倍率。
+- `ReloadSpeedGain` - 装填速度增益。
+- `GunCritRateGain` - 枪械暴击率增益。
+- `GunCritDamageGain` - 枪械暴击伤害增益。
+- `GunBulletSpeedMultiplier` - 子弹速度倍率。
+- `RecoilControl` - 后坐力控制。
+- `GunScatterMultiplier` - 枪械散布倍率。
+- `InventoryCapacity` - 背包容量加成。
+- `HasGasMask` - 是否装备防毒面具。
+- `WalkSoundRange` - 步行声音范围。
+- `RunSoundRange` - 奔跑声音范围。
+- `FlashLight` - 是否启用手电。
+- `SoundKey` - 当前音效 Key。
+
+#### 主要方法
+- `GetAimRange()` - 依据瞄准类型与装备计算射程。
+- `GetCurrentAimPoint()` - 获取当前输入瞄准点。
+- `GetCurrentSkillAimPoint()` - 获取当前技能瞄准点。
+- `SwitchWeapon(int dir)` - 按方向切换武器（-1 近战，0 主武器，1 副武器）。
+- `CanEditInventory()` - 当前状态是否允许打开背包。
+- `SetMoveInput(Vector3 moveInput)` - 设置移动输入。
+- `MeleeWeaponSlot()` / `PrimWeaponSlot()` / `SecWeaponSlot()` - 获取对应武器槽位。
+- `GetSlot(int hash)` - 通过槽位哈希获取槽位。
+- `SwitchToFirstAvailableWeapon()` - 切换到首个可用武器。
+- `SwitchToWeapon(int index)` - 切换到指定索引的武器。
+- `ToggleNightVision()` - 切换夜视。
+- `Dash()` - 执行冲刺动作。
+- `TryCatchFishInput()` - 钓鱼时尝试收杆。
+- `HasNearByHalfObsticle()` - 检查附近是否有半掩体。
+- `SwitchToWeaponBeforeUse()` - 恢复使用物品前的武器。
+- `SetForceMoveVelocity(Vector3 velocity)` - 设置强制移动速度。
+- `SetAimPoint(Vector3 aimPoint)` - 设置瞄准点。
+- `Attack()` - 执行近战攻击，返回是否成功。
+- `SetAimType(AimTypes aimType)` - 设置瞄准类型。
+- `SetRunInput(bool run)` / `SetAdsInput(bool ads)` - 设置奔跑/瞄准输入状态。
+- `TryToReload(Item preferedBulletToLoad = null)` - 尝试装填弹药，可传入优先子弹。
+- `SetSkill(SkillTypes skillType, SkillBase skill, GameObject bindingObject)` - 绑定技能。
+- `StartSkillAim(SkillTypes skillType)` - 开始技能瞄准。
+- `ReleaseSkill(SkillTypes skillType)` - 释放技能。
+- `CancleSkill()` - 取消技能。
+- `GetCurrentRunningSkill()` - 获取当前执行的技能。
+- `GetGunReloadable()` - 当前枪械是否可装填。
+- `CanUseHand()` - 是否可以进行手部操作。
+- `CanControlAim()` - 是否可以控制瞄准。
+- `StartAction(CharacterActionBase newAction)` - 尝试启动新的角色动作。
+- `SwitchHoldAgentInSlot(int slotHash)` - 切换指定槽位的持有物。
+- `SwitchInteractSelection(int dir)` - 在可交互对象中切换选择。
+- `SetTeam(Teams team)` - 设置队伍。
+- `GetGun()` / `GetMeleeWeapon()` - 获取当前枪械或近战代理。
+- `ChangeHoldItem(Item item)` - 切换持有物品。
+- `SetItem(Item item)` - 直接设置角色物品。
+- `Trigger(bool trigger, bool triggerThisFrame, bool releaseThisFrame)` - 处理触发器输入。
+- `CanMove()` - 是否允许移动。
+- `PopText(string text, float speed = -1f)` - 在角色上弹出文本。
+- `CanRun()` - 当前状态是否允许奔跑。
+- `IsAiming()` - 是否正在瞄准。
+- `DestroyCharacter()` - 销毁角色实体。
+- `TriggerShootEvent(DuckovItemAgent shootByAgent)` - 手动触发射击事件。
+- `SetCharacterModel(CharacterModel characterModel)` - 绑定角色模型。
+- `TickVariables(float deltaTime, float tickTime)` - 更新角色缓存参数。
+- `UpdateThirstyAndStarve()` - 更新饥渴状态。
+- `UpdateWeightState()` - 更新负重状态。
+- `PickupItem(Item item)` - 拾取物品。
+- `GetInteractableTargetToInteract()` - 获取当前可交互目标。
+- `Interact(InteractableBase target)` / `Interact()` - 执行交互。
+- `AddHealth(float healthValue)` - 增加生命值。
+- `SetRelatedScene(int relatedScene, bool setActiveByPlayerDistance = true)` - 绑定相关场景并根据距离激活。
+- `Carry(Carriable target)` - 搬运可携带物体。
+- `AddEnergy(float energyValue)` - 增加精力。
+- `AddWater(float waterValue)` - 增加水分。
+- `DropAllItems()` - 丢弃所有物品。
+- `DestroyAllItem()` - 销毁所有物品。
+- `DestroyItemsThatNeededToBeDestriedInBase()` - 在基地销毁需要移除的物品。
+- `AddSubVisuals(CharacterSubVisuals subVisuals)` / `RemoveVisual(CharacterSubVisuals subVisuals)` - 添加或移除子视觉。
+- `Hide()` / `Show()` - 隐藏或显示角色。
+- `IsNearByHalfObsticle(GameObject target)` - 判断指定对象是否半掩体。
+- `GetNearByHalfObsticles()` - 获取附近半掩体列表。
+- `AddnearByHalfObsticles(List<GameObject> objs)` / `RemoveNearByHalfObsticles(List<GameObject> objs)` - 管理附近半掩体列表。
+- `UseItem(Item item)` - 使用物品。
+- `GetBuffManager()` - 获取 Buff 管理器。
+- `AddBuff(Buff buffPrefab, CharacterMainControl fromWho = null, int overrideWeaponID = 0)` - 添加 Buff。
+- `RemoveBuff(int buffID, bool removeOneLayer)` - 移除指定 Buff。
+- `RemoveBuffsByTag(Buff.BuffExclusiveTags tag, bool removeOneLayer)` - 按标签移除 Buff。
+- `HasBuff(int buffID)` - 检查是否拥有 Buff。
+- `SetPosition(Vector3 pos)` - 设置角色位置并触发事件。
+- `GetArmorItem()` / `GetHelmatItem()` / `GetFaceMaskItem()` - 获取护甲相关物品。
+- `WeaponRepairLossFactor()` / `EquipmentRepairLossFactor()` - 静态方法，返回维修损耗系数。
+- `UseStamina(float value)` - 消耗耐力。
+
+---
 
 ### LevelManager
-关卡管理器，负责管理游戏关卡的加载、初始化和状态。
+关卡管理器，负责关卡加载、初始化与核心系统引用。
 
 #### 静态属性
-- `Instance` - 获取LevelManager实例
-- `LootBoxInventoriesParent` - 战利品箱背包父对象
-- `LootBoxInventories` - 战利品箱背包字典
-- `LevelInitializing` - 关卡是否正在初始化
-- `AfterInit` - 是否在初始化后
-- `LevelInited` - 关卡是否已初始化
-- `LevelInitializingComment` - 关卡初始化注释
-- `OnLevelInitializingCommentChanged` - 关卡初始化注释改变事件
-- `OnLevelBeginInitializing` - 关卡开始初始化事件
-- `OnLevelInitialized` - 关卡初始化完成事件
-- `OnAfterLevelInitialized` - 关卡初始化后事件
-- `OnEvacuated` - 撤离事件
-- `OnMainCharacterDead` - 主角色死亡事件
-- `OnNewGameReport` - 新游戏报告事件
-- `Rule` - 规则集
+- `Instance` - 获取 LevelManager 单例。
+- `LootBoxInventoriesParent` - 战利品箱背包的父节点。
+- `LootBoxInventories` - 战利品箱背包缓存字典。
+- `LevelInitializing` - 是否处于初始化流程。
+- `AfterInit` - 是否已进入初始化后阶段。
+- `LevelInitializingComment` - 当前初始化状态描述。
+- `LevelInited` - 关卡是否完成初始化。
+- `Rule` - 当前应用的规则集。
+
+#### 公有属性
+- `IsRaidMap` - 是否为突袭关卡。
+- `IsBaseLevel` - 是否为基地场景。
+- `InputManager` - 输入管理器实例。
+- `CharacterCreator` - 角色生成器。
+- `ExitCreator` - 撤离点创建器。
+- `ExplosionManager` - 爆炸效果管理器。
+- `MainCharacter` - 主角色控制器。
+- `PetCharacter` - 宠物角色控制器。
+- `GameCamera` - 游戏相机。
+- `FogOfWarManager` - 战争迷雾管理器。
+- `TimeOfDayController` - 昼夜控制器。
+- `AIMainBrain` - AI 主脑。
+- `PetProxy` - 宠物代理。
+- `BulletPool` - 子弹对象池。
+- `CustomFaceManager` - 捏脸管理器。
+- `LevelTime` - 关卡已运行时间（秒）。
+
+#### 公有字段
+- `defaultSkill` - 默认技能实例。
+- `loadLevelBeaconIndex` - 加载关卡时的信标索引。
+- `MainCharacterItemSaveKey` - 主角物品存档键名。
+- `MainCharacterHealthSaveKey` - 主角生命存档键名。
+
+#### 静态事件
+- `OnLevelBeginInitializing` - 关卡开始初始化时触发。
+- `OnLevelInitialized` - 关卡初始化完成时触发。
+- `OnAfterLevelInitialized` - 初始化后回调。
+- `OnLevelInitializingCommentChanged` - 初始化状态描述更新时回调。
+- `OnEvacuated` - 撤离事件。
+- `OnMainCharacterDead` - 主角死亡事件。
+- `OnNewGameReport` - 新游戏汇报事件。
+
+#### 主要方法
+- `RegisterWaitForInitialization<T>(T toWait)` - 注册在初始化完成前需要等待的对象（实现 `IInitializedQueryHandler`）。
+- `UnregisterWaitForInitialization<T>(T obj)` - 取消注册等待对象。
+- `RefreshMainCharacterFace()` - 刷新主角外观。
+- `NotifyEvacuated(EvacuationInfo info)` - 通知撤离并触发事件。
+- `NotifySaveBeforeLoadScene(bool saveToFile)` - 在加载场景前保存数据。
+- `TestTeleport()` - 调试用传送函数。
+- `GetCurrentLevelInfo()` - 获取当前关卡信息结构体。
+
+#### 结构体
+- `LevelInfo` - 描述关卡信息，包含 `isBaseLevel`、`sceneName`、`activeSubSceneID` 字段。
+
+---
 
 ### HUDManager
-HUD管理器，负责管理游戏界面的显示和隐藏。
+HUD 管理器，负责处理 UI HUD 的显示开关。
 
 #### 静态方法
-- `RegisterHideToken(UnityEngine.Object obj)` - 注册隐藏令牌
-- `UnregisterHideToken(UnityEngine.Object obj)` - 注销隐藏令牌
+- `RegisterHideToken(UnityEngine.Object obj)` - 注册隐藏 HUD 的令牌。
+- `UnregisterHideToken(UnityEngine.Object obj)` - 释放隐藏令牌。
+
+---
 
 ### CraftingManager
-制作管理器，负责管理游戏中的制作配方和制作系统。
+制作管理器，负责制作配方解锁与制造流程。
 
 #### 静态属性
-- `Instance` - 获取CraftingManager实例
-- `UnlockedFormulaIDs` - 已解锁的配方ID集合
+- `Instance` - 当前 CraftingManager 单例（仅内部设置）。
+- `UnlockedFormulaIDs` - 当前已解锁的配方 ID 枚举。
 
-#### 事件
-- `OnItemCrafted` - 物品制作完成事件
-- `OnFormulaUnlocked` - 配方解锁事件
+#### 静态事件
+- `OnItemCrafted` - 物品制作完成事件，提供配方与产出物品。
+- `OnFormulaUnlocked` - 配方被解锁时触发。
 
 #### 静态方法
-- `UnlockFormula(string formulaID)` - 解锁配方
-- `IsFormulaUnlocked(string value)` - 检查配方是否已解锁
-- `GetFormula(string id)` - 获取配方
+- `UnlockFormula(string formulaID)` - 解锁指定配方。
+- `IsFormulaUnlocked(string value)` *(internal)* - 检查配方是否解锁。
+- `GetFormula(string id)` *(internal)* - 获取配方定义。
 
 #### 方法
-- `Craft(string id)` - 制作物品
-- `Craft(CraftingFormula formula)` - 制作物品（配方）
+- `Craft(string id)` - 根据配方 ID 制作物品，返回异步的物品列表。
+
+---
 
 ### InputManager
-输入管理器，负责处理玩家输入和输入设备管理。
+输入管理器，负责处理玩家输入、设备切换与角色交互。
 
 #### 静态属性
-- `InputDevice` - 当前输入设备
-- `InputActived` - 输入是否激活
+- `InputDevice` - 当前使用的输入设备枚举。
+- `InputActived` - 是否允许输入。
 
-#### 属性
-- `WorldMoveInput` - 世界移动输入
-- `AimTarget` - 瞄准目标
-- `MoveAxisInput` - 移动轴输入
-- `AimScreenPoint` - 瞄准屏幕点
-- `InputAimPoint` - 输入瞄准点
-- `MousePos` - 鼠标位置
-- `TriggerInput` - 触发输入
-- `AimingEnemyHead` - 是否瞄准敌人头部
+#### 公有属性
+- `WorldMoveInput` - 世界坐标系下的移动输入。
+- `AimTarget` - 当前瞄准目标。
+- `MoveAxisInput` - 原始移动轴输入。
+- `AimScreenPoint` - 屏幕坐标瞄准点。
+- `InputAimPoint` - 计算后的世界瞄准点。
+- `MousePos` - 鼠标位置。
+- `TriggerInput` - 是否触发开火输入。
+- `AimingEnemyHead` - 是否瞄准敌人头部。
 
-#### 事件
-- `OnInputDeviceChanged` - 输入设备改变事件
-- `OnSwitchBulletTypeInput` - 切换子弹类型输入事件
-- `OnSwitchWeaponInput` - 切换武器输入事件
-- `OnInteractButtonDown` - 交互按钮按下事件
+#### 公有字段
+- `characterMainControl` - 关联的主角色控制器。
+- `aimTargetFinder` - 瞄准目标搜索器。
+- `runThreshold` - 摇杆判定奔跑的阈值。
+- `OnInteractButtonDown` - 静态事件，交互键按下时触发。
+- `PrimaryWeaponSlotHash` / `SecondaryWeaponSlotHash` / `MeleeWeaponSlotHash` - 槽位哈希常量。
+- `useRunInputBuffer` - 静态标记，是否启用奔跑输入缓冲。
 
-### Health
-生命值系统，管理角色的生命值和伤害计算。
+#### 静态事件
+- `OnInputDeviceChanged` - 输入设备切换时触发。
+- `OnSwitchBulletTypeInput` - 请求切换子弹类型时触发，参数为方向。
+- `OnSwitchWeaponInput` - 请求切换武器时触发，参数为方向。
 
-#### 属性
-- `showHealthBar` - 是否显示血条
-- `Hidden` - 是否隐藏
-- `MaxHealth` - 最大生命值
-- `IsMainCharacterHealth` - 是否是主角色生命值
-- `CurrentHealth` - 当前生命值
-- `IsDead` - 是否死亡
-- `Invincible` - 是否无敌
-- `BodyArmor` - 身体护甲
-- `HeadArmor` - 头部护甲
-
-#### 事件
-- `OnHurt` - 受伤事件
-- `OnDead` - 死亡事件
-- `OnRequestHealthBar` - 请求血条事件
-- `OnHealthChange` - 生命值改变事件
-- `OnMaxHealthChange` - 最大生命值改变事件
-
-### ModBehaviour
-Mod行为基类，所有Mod必须继承此类。
-
-#### 属性
-- `master` - Mod管理器
-- `info` - Mod信息
+#### 静态方法
+- `DisableInput(GameObject source)` - 禁用输入（记录来源）。
+- `ActiveInput(GameObject source)` - 启用输入。
+- `SetInputDevice(InputManager.InputDevices inputDevice)` - 切换输入设备。
 
 #### 方法
-- `Setup(ModManager master, ModInfo info)` - 设置Mod
-- `NotifyBeforeDeactivate()` - 通知停用前
-- `OnAfterSetup()` - 设置后回调（可重写）
-- `OnBeforeDeactivate()` - 停用前回调（可重写）
+- `SetTrigger(bool trigger, bool triggerThisFrame, bool releaseThisFrame)` - 设置触发器输入状态。
+- `SetSwitchBulletTypeInput(int dir)` - 触发切换子弹类型输入。
+- `SetSwitchWeaponInput(int dir)` - 触发切换武器输入。
+- `SetSwitchInteractInput(int dir)` - 触发交互对象切换。
+- `SetMoveInput(Vector2 axisInput)` - 设置移动轴输入。
+- `SetRunInput(bool run)` - 设置奔跑输入。
+- `SetAdsInput(bool ads)` - 设置瞄准输入。
+- `ToggleView()` - 切换视角。
+- `ToggleNightVision()` - 切换夜视。
+- `SetAimInputUsingJoystick(Vector2 joystickAxisInput)` - 通过摇杆设置瞄准输入。
+- `SetAimType(AimTypes aimType)` - 设置瞄准类型。
+- `SetMousePosition(Vector2 mousePosition)` - 记录鼠标位置。
+- `SetAimInputUsingMouse(Vector2 mouseDelta)` - 根据鼠标增量调整瞄准。
+- `Interact()` - 请求交互。
+- `PutAway()` - 收起当前物品。
+- `SwitchItemAgent(int index)` - 切换手持物品代理。
+- `StopAction()` - 停止当前动作。
+- `ReleaseItemSkill()` - 释放物品技能。
+- `ReleaseCharacterSkill()` - 释放角色技能。
+- `CancleSkill()` - 取消技能并返回是否成功。
+- `Dash()` - 请求冲刺。
+- `StartCharacterSkillAim()` - 开始角色技能瞄准。
+- `StartItemSkillAim()` - 开始物品技能瞄准。
+- `AddRecoil(ItemAgent_Gun gun)` - 根据枪械添加后坐力。
+
+---
+
+### Health
+生命值系统组件，负责记录生命、护甲、伤害计算与 Buff 应用。
+
+#### 公有属性
+- `showHealthBar` - 是否显示血条。
+- `Hidden` - 是否隐藏血条显示。
+- `MaxHealth` - 最大生命值。
+- `IsMainCharacterHealth` - 是否为主角生命组件。
+- `CurrentHealth` - 当前生命值。
+- `IsDead` - 是否死亡。
+- `Invincible` - 是否无敌。
+- `BodyArmor` - 身体护甲值。
+- `HeadArmor` - 头部护甲值。
+
+#### 公有字段
+- `team` - 所属队伍。
+- `hasSoul` - 是否在死亡后保留灵魂。
+- `OnHealthChange` - 生命值变化 UnityEvent。
+- `OnMaxHealthChange` - 最大生命值变化 UnityEvent。
+- `healthBarHeight` - 血条高度。
+- `autoInit` - 是否在 Awake 时自动初始化。
+
+#### 静态事件
+- `OnHurt` - 受伤时触发，提供 Health 与伤害信息。
+- `OnDead` - 死亡时触发。
+- `OnRequestHealthBar` - 请求显示血条事件。
+
+#### 主要方法
+- `TryGetCharacter()` - 获取关联的角色控制器。
+- `ElementFactor(ElementTypes type)` - 获取对应元素伤害修正。
+- `SetItemAndCharacter(Item item, CharacterMainControl character)` - 绑定物品与角色。
+- `Init()` - 初始化生命组件。
+- `AddBuff(Buff buffPrefab, CharacterMainControl fromWho, int overrideFromWeaponID = 0)` - 为生命组件添加 Buff。
+- `Hurt(DamageInfo damageInfo)` - 处理伤害，返回是否成功命中。
+- `RequestHealthBar()` - 主动请求显示血条。
+- `DestroyOnDelay()` - 延迟销毁（返回 `UniTask`）。
+- `AddHealth(float healthValue)` - 增加生命值。
+- `SetHealth(float healthValue)` - 设置生命值。
+- `SetInvincible(bool value)` - 设置无敌状态。
+
+---
+
+### ModBehaviour
+Mod 行为抽象基类，所有 Mod 需继承此类。
+
+#### 公有属性
+- `master` - Mod 管理器实例（仅内部赋值）。
+- `info` - Mod 元信息（仅内部赋值）。
+
+#### 公有方法
+- `Setup(ModManager master, ModInfo info)` - 初始化 Mod，并调用 `OnAfterSetup`。
+- `NotifyBeforeDeactivate()` - 模块停用前通知，调用 `OnBeforeDeactivate`。
+
+#### 可重写方法
+- `OnAfterSetup()` - Setup 完成后回调，可重写执行初始化逻辑。
+- `OnBeforeDeactivate()` - 停用前回调，可重写清理逻辑。
+
+---
+
+### CharacterInputControl
+玩家输入控制器，负责将 `PlayerInput` 动作映射到 `InputManager`，并在角色初始化后持续推送输入状态。
+
+#### 静态属性
+- `Instance` *(static)* - 当前激活的输入控制器单例。
+
+#### 公有字段
+- `inputManager` - 绑定的 `InputManager` 实例。
+- `MoveAxis` / `Run` / `ADS` - 对应移动、奔跑与瞄准的输入动作。
+- `MousePos` / `MouseDelta` - 鼠标位置与增量输入。
+- `Trigger` - 武器触发输入动作。
+- `ScrollWheel` - 鼠标滚轮输入（用于切换武器/交互目标）。
+- `SwitchWeapon` / `SwitchInteractAndBulletType` / `SwitchBulletType` - 武器与子弹切换输入。
+- `ItemShortcut1` ~ `ItemShortcut8` / `ItemShortcut_Melee` - 快捷物品槽输入动作。
+- `Skill_1_StartAim` - 角色技能瞄准输入。
+- `Reload` / `StopAction` / `PutAway` / `Dash` / `CancelSkill` 等用于动作控制的输入引用。
+- `UI_Inventory` / `UI_Map` / `UI_Quest` - UI 打开/关闭输入。
+
+#### 主要方法
+- `OnPlayerMoveInput(InputAction.CallbackContext context)` - 更新角色移动输入。
+- `OnPlayerRunInput(InputAction.CallbackContext context)` - 切换奔跑状态。
+- `OnPlayerAdsInput(InputAction.CallbackContext context)` - 设置瞄准输入标记。
+- `OnPlayerMouseMove(InputAction.CallbackContext context)` / `OnPlayerMouseDelta(InputAction.CallbackContext context)` - 推送鼠标指针与增量。
+- `OnPlayerTriggerInputUsingMouseKeyboard(InputAction.CallbackContext context)` - 处理鼠标左键触发器输入，并记录本帧状态。
+- `OnToggleViewInput(InputAction.CallbackContext context)` / `OnToggleNightVisionInput(InputAction.CallbackContext context)` - 切换视角或夜视。
+- `OnReloadInput(InputAction.CallbackContext context)` / `OnPlayerStopAction(InputAction.CallbackContext context)` / `OnPutAwayInput(InputAction.CallbackContext context)` - 映射常用操作至 `InputManager`。
+- `OnDashInput(InputAction.CallbackContext context)` - 请求冲刺。
+- `OnInteractInput(InputAction.CallbackContext context)` / `OnSwitchInteractAndBulletTypeInput(InputAction.CallbackContext context)` - 执行交互与交互目标切换。
+- `OnSwitchWeaponInput(InputAction.CallbackContext context)` / `OnMouseScollerInput(InputAction.CallbackContext context)` - 响应武器切换与滚轮输入。
+- `OnPlayerSwitchItemAgent1/2/.../Melee(InputAction.CallbackContext context)` 与 `OnShortCutInput3~8(InputAction.CallbackContext context)` - 响应快捷物品槽切换。
+- `OnUIInventoryInput(InputAction.CallbackContext context)` / `OnUIMapInput(InputAction.CallbackContext context)` / `OnUIQuestViewInput(InputAction.CallbackContext context)` - 打开或关闭界面。
+- `OnStartCharacterSkillAim(InputAction.CallbackContext context)` / `OnCharacterSkillRelease(InputAction.CallbackContext context)` - 控制角色技能瞄准与释放。
+- `OnCancelSkillInput(InputAction.CallbackContext context)` - 请求取消技能。
+- `GetChangeBulletTypeWasPressed()` - 查询本帧是否触发子弹类型切换。
+
+---
+
+### CharacterActionBase 及派生动作
+角色动作体系的基类与具体实现，驱动角色在执行互动、攻击、技能时的进度状态。
+
+#### CharacterActionBase
+- `Running` - 当前动作是否执行中。
+- `ActionTimer` - 经过时间。
+- `ActionPriorities` - 动作优先级枚举。
+- `UpdateAction(float deltaTime)` - 每帧更新动作。
+- `StartActionByCharacter(CharacterMainControl character)` - 绑定角色并启动动作。
+- `StopAction()` - 强制停止动作并重置状态。
+
+#### CA_Attack
+- `DamageDealed` - 最近一次造成的伤害值。
+- `GetProgress()` - 当前攻击动作的进度。
+
+#### CA_Carry
+- `GetWeight()` - 返回被搬运目标的重量信息。
+- `GetProgress()` - 当前搬运动作进度。
+
+#### CA_Interact
+- `MasterInteractableAround` - 最近检测到的交互体集合。
+- `InteractTarget` - 当前锁定的交互对象。
+- `InteractIndexInGroup` - 当前组内索引。
+- `InteractingTarget` - 正在执行交互的对象引用。
+- `SearchInteractableAround(bool includeMultiInteraction)` - 搜索周围可交互目标。
+- `SwitchInteractable(int dir)` - 按方向切换交互对象。
+- `SetInteractableTarget(InteractableBase interactable)` - 指定交互目标。
+- `GetProgress()` - 获取当前交互进度。
+
+#### CA_Skill
+- `CurrentRunningSkill` - 当前执行中的技能引用。
+- `GetSkillKeeper()` - 返回技能保持器。
+- `IsSkillHasEnoughStaminaAndCD(SkillTypes type)` - 检测技能冷却与体力。
+- `SetNextSkillType(SkillTypes type)` - 指定下一次技能类型。
+- `SetSkillOfType(SkillTypes type, SkillBase skill)` - 绑定技能实例。
+- `ReleaseSkill(SkillTypes type)` - 请求释放技能。
+- `GetProgress()` - 返回技能动作进度。
+
+---
+
+### CharacterEquipmentController
+装备控制器，负责维护角色各个装备槽位并监听装备变化。
+
+#### 静态字段
+- `equipmentModelHash` / `armorHash` / `helmatHash` / `faceMaskHash` / `backpackHash` / `headsetHash` - 不同装备槽位的哈希常量。
+
+#### 公有事件
+- `OnHelmatSlotContentChanged` - 头盔槽内容更新时回调。
+- `OnFaceMaskSlotContentChanged` - 面罩槽内容更新时回调。
+
+#### 主要方法
+- `SetItem(Slot slot, Item item)` - 为指定槽位设置装备，并触发对应事件。
+
+---
+
+### CharacterRandomPreset
+角色随机预设数据，定义 AI 或 NPC 的初始配置、属性与掉落。
+
+#### 公有字段（节选）
+- `nameKey` - 名称本地化键。
+- `voiceType` / `footstepMaterialType` - 语音与脚步音效类型。
+- `lootBoxPrefab` - 对应的战利品箱预制体。
+- `team` - 预设所属队伍。
+- `showName` / `showHealthBar` / `hasSoul` - 外观表现与灵魂配置。
+- `health` / `exp` / `moveSpeedFactor` 等基础数值。
+- `specialAttachmentBases` / `buffs` / `buffResist` - 附加特殊附件、初始 Buff 与抗性列表。
+- `sightDistance` / `sightAngle` / `reactionTime` / `forgetTime` - AI 感知与反应参数。
+- `shootDelay` / `shootTimeRange` / `shootTimeSpaceRange` / `combatMoveRange` - 战斗行为配置。
+- `dashCoolTimeRange` / `skillCoolTimeRange` / `skillSuccessChance` 等技能与冲刺参数。
+- `wantItem` / `hasCashChance` / `cashRange` - 战利品偏好。
+
+#### 主要方法
+- `GetCharacterIcon()` - 根据预设生成角色图标。
+- `CreateCharacterAsync(CharacterCreator creator, Transform parent)` - 异步创建角色实例并返回 `UniTask`。
+
+---
+
+### CharacterModel 与 CharacterSubVisuals
+角色模型与子视觉系统，负责角色外观、挂载点与特效管理。
+
+#### CharacterModel
+- 关键字段：`characterMainControl`、`modelRoot`、`RightHandSocket`、`damageReceiverRadius` 等。
+- 事件：`OnDestroyEvent`、`OnCharacterSetEvent`、`OnAttackOrShootEvent`。
+- 主要方法：
+  - `OnMainCharacterSetted(CharacterMainControl character)` - 绑定主角引用。
+  - `AddSubVisuals(CharacterSubVisuals visuals)` / `RemoveVisual(CharacterSubVisuals visuals)` - 管理附属视觉。
+  - `SyncHiddenToMainCharacter()` - 同步隐藏状态。
+  - `SetFaceFromPreset(CharacterRandomPreset preset)` / `SetFaceFromData(CustomFacePreset presetData)` - 设置自定义脸部。
+  - `ForcePlayAttackAnimation()` - 强制播放攻击动画。
+
+#### CharacterSubVisuals
+- 字段：`renderers`、`particles`、`lights`、`sodaPointLights`、`mainModel` 等。
+- 方法：`AddRenderer(Renderer renderer)`、`SetRenderersHidden(bool hidden)`、`SetCharacter(CharacterModel model)`。
+
+---
+
+### Movement
+角色运动组件，封装移动输入与强制运动逻辑。
+
+#### 公有字段
+- `characterController` - 关联的 `CharacterMainControl`。
+- `targetAimDirection` - 目标朝向。
+- `forceMove` / `forceMoveVelocity` - 强制移动标记与速度。
+
+#### 主要方法
+- `SetMoveInput(Vector3 moveInput)` - 设置移动输入向量。
+- `SetForceMoveVelocity(Vector3 velocity)` - 施加强制移动。
+- `SetAimDirection(Vector3 aimDirection)` / `SetAimDirectionToTarget(Transform target)` - 调整瞄准方向。
+- `ForceTurnTo(Vector3 direction)` / `ForceSetAimDirectionToAimPoint(Vector3 aimPoint)` - 瞬间旋转至目标。
+- `GetMoveAnimationValue()` / `GetLocalMoveDirectionAnimationValue()` - 获取动画驱动的速度与方向值。
+
+---
+
+### ItemAgentHolder 与物品代理
+负责角色持有的武器/物品代理管理。
+
+#### ItemAgentHolder
+- 属性：`CurrentHoldItemAgent`、`CurrentUsingSocket`、`CurrentHoldGun`、`CurrentHoldMeleeWeapon`、`Skill`。
+- 事件：`OnHoldAgentChanged` - 持有代理变更时触发。
+- 方法：`ChangeHoldItemAgent(DuckovItemAgent agent)`、`SwitchHoldAgentInSlot(int slotHash)`。
+
+#### ItemAgent_Gun
+- 关键属性：`BulletItem`、`ShootSpeed`、`ReloadTime`、`Capacity`、`Durability` / `MaxDurability`、`Damage`、`BurstCount`、`BulletSpeed`、`BulletDistance`、`Penetrate`、`ExplosionDamageMultiplier`、`CritRate`、`CritDamageFactor`、`SoundRange`、`Silenced`、`ArmorPiercing`、`ArmorBreak`、`ShotCount`。
+- 事件：`OnMainCharacterShootEvent`、`OnShootEvent`、`OnLoadedEvent`。
+- 主要方法：`GetReloadProgress()`、`GetBulletCount()`、`TryShoot()`、`Shoot(Vector3 aimPoint)`、`Reload(Item preferedBullet)`、`ForceSetBullet(Item bullet)`、`UnloadBullet()`、`PlayTriggerSound()`、`AddRecoil(float amount)`、`GetAmmoDescription()`。
+
+#### ItemAgent_MeleeWeapon
+- 属性：`Damage`、`CritRate`、`CritDamageFactor`、`ArmorPiercing`、`AttackSpeed`、`AttackRange`、`DealDamageTime`、`StaminaCost`、`BleedChance`、`MoveSpeedMultiplier`、`CharacterDamageMultiplier`、`CharacterCritRateGain`、`CharacterCritDamageGain`、`SoundKey`。
+- 方法：`GetAttackProgress()`、`RequestAttack()`。
+
+#### AccessoryBase / Accessory_Lazer
+- `AccessoryBase` 提供 `OnItemSet(Item item)` 等初始化钩子供子类实现。
+- `Accessory_Lazer` 派生类，开启/关闭激光瞄具并更新可视特效。
+
+---
+
+### 角色创建与自定义外观
+
+#### CharacterCreator
+- 字段：`characterPfb` - 角色预制体。
+- 方法：`CreateCharacter(CharacterRandomPreset preset, Transform parent)`、`LoadOrCreateCharacterItemInstance(Item item)`。
+
+#### CharacterSpawnerGroupSelector
+- 字段：`spawnerRoot`、`groups`、`spawnGroupCountRange`。
+- 方法：`Collect()` - 从子节点收集分组；`RandomSpawn()` - 根据范围随机生成角色。
+
+#### CustomFace 系统
+- `CustomFaceUI` - 管理自定义外观界面，包含 `tabs`、`skinColorPicker`、各类滑杆与颜色选择器，事件 `OnCustomUIViewChanged`。主要方法：`OpenTab(int index)`、`ApplyPreset(CustomFacePreset preset)`、`SetCanControl(bool canControl)`、`Randomize()`、`ResetToDefault()`、`Apply()`。
+- `CustomFaceInstance` - 实时应用外观数据，事件 `OnLoadFaceData`，方法：`ApplyPreset(CustomFacePreset preset)`、`ApplyData(CustomFacePreset preset)`、`SetCustomColor(string key, Color color)`、`GetSocket(CustomFacePartTypes partType)`、`TryGetPartUtility(CustomFacePartTypes partType, out CustomFacePartUtility utility)`。
+- `CustomFacePart` / `CustomFacePartInfo` / `CustomFacePartMeta` / `CustomFacePartTypes` - 定义可替换部件、元数据与枚举。
+- `CustomFacePartUtility` - 管理部件实例，方法：`SetInstance(CustomFaceInstance instance)`、`ApplyPart(CustomFacePreset preset)`、`ApplyColor(Color color)`、`Reset()`。
+- `CustomFaceUIColorPicker` / `CustomFaceUIColorPickerButton` - 颜色选择 UI，事件 `OnSetColor`，方法：`Init(CustomFaceUI master)`、`SetColor(Color color)`、`SetSelected(bool selected)`。
+
+---
+
+### 输入与 UI 系统
+
+#### InputManager
+- 字段：`characterMainControl`、`aimTargetFinder`、`runThreshold`。
+- 静态字段：`PrimaryWeaponSlotHash`、`SecondaryWeaponSlotHash`、`MeleeWeaponSlotHash`、`useRunInputBuffer`。
+- 静态事件：`OnInputDeviceChanged`、`OnSwitchBulletTypeInput`、`OnSwitchWeaponInput`、`OnInteractButtonDown`。
+- 主要方法：`SetTrigger(bool trigger, bool triggerThisFrame, bool releaseThisFrame)`、`SetMoveInput(Vector2 axis)`、`SetRunInput(bool run)`、`SetAdsInput(bool ads)`、`ToggleView()`、`ToggleNightVision()`、`SetAimInputUsingJoystick(Vector2 axis)`、`SetAimInputUsingMouse(Vector2 delta)`、`Interact()`、`PutAway()`、`SwitchItemAgent(int index)`、`StopAction()`、`ReleaseItemSkill()`、`ReleaseCharacterSkill()`、`CancleSkill()`、`Dash()`、`StartCharacterSkillAim()`、`StartItemSkillAim()`、`AddRecoil(ItemAgent_Gun gun)`。
+
+#### UIInputManager
+- 静态属性：`Instance`。
+- 属性：`Ctrl`、`Alt`、`Shift`、`Point`、`MouseDelta`、`WasClickedThisFrame`。
+- 静态事件：`OnNavigate`、`OnConfirm`、`OnToggleIndicatorHUD`、`OnCancelEarly`、`OnCancel`、`OnFastPick`、`OnDropItem`、`OnUseItem`、`OnToggleCameraMode`、`OnWishlistHoveringItem`、`OnNextPage`、`OnPreviousPage`、`OnLockInventoryIndex`、`OnInteractInputContext`。
+- 方法：`GetPointRay(Camera camera)` - 根据当前指针位置获取射线。
+
+#### InputRebinder 与 CharacterTouchInputControl
+- `InputRebinder` 暴露事件：`OnRebindBegin`、`OnRebindComplete`、`OnBindingChanged`，方法：`RebindAction(string actionName)`、`ResetBinding(string actionName)`、`RestoreDefaults()`、`GetDisplayName(InputBinding binding)`、`SaveBindingOverrides()`。
+- `InputRebinderIndicator` - UI 组件，用于展示当前按键绑定。
+- `CharacterTouchInputControl` - 面向触控的输入代理，方法：`SetMoveInput(Vector2 axis)`、`SetRunInput(bool run)`、`SetAdsInput(bool ads)`、`SetGunAimInput(Vector2 aim)`、`SetCharacterSkillAimInput(Vector2 aim)`、`StartCharacterSkillAim()`、`CharacterSkillRelease()`、`SetItemSkillAimInput(Vector2 aim)`、`StartItemSkillAim()`、`ItemSkillRelease()`。
+
+#### MultiInteraction 与 HUD
+- `MultiInteraction` - 聚合多个 `InteractableBase`，属性 `Interactables` 用于 UI 呈现。
+- `MultiInteractionMenuButton` - HUD 按钮组件，提供 `Setup(MultiInteraction multiInteraction, int index)`、`OnClick()` 等回调。
+- `InteractSelectionHUD` - 管理交互目标选择，属性 `InteractTarget`，方法：`SetInteractable(MultiInteraction multi, int selection)`、`SetSelection(int index)`。
+- `InteractHUD` - 单一交互提示 UI。
+- `NotificationProxy` - 方法：`Notify(string text, NotificationProxy.Types type, Sprite icon = null)`。
+- `DialogueBubbleProxy` - 方法：`Pop(string text)`、`Pop(string text, DuckovDialogueActor actor)`。
+- `StaminaHUD` / `SkillHUD` - UI 控件，分别负责耐力与技能状态显示（主要通过序列化字段驱动）。
+
+---
+
+### 场景与相机系统
+
+#### GameCamera
+- 静态属性：`Instance`。
+- 属性：`CameraAimingTypes` - 当前瞄准模式。
+- 方法：`UpdateFov(float fov)`、`ForceSyncPos()`、`SetTarget(Transform target)`、`UpdatePosition(float deltaTime)`、`IsOffScreen(Vector3 worldPos)`。
+
+#### SceneLoader
+- 静态属性：`Instance`、`IsSceneLoading`、`LoadingComment`、`HideTips`。
+- 事件：`onStartedLoadingScene`、`onFinishedLoadingScene`、`onBeforeSetSceneActive`、`onAfterSceneInitialize`、`OnSetLoadingComment`。
+- 方法：`LoadScene(string sceneName, bool additive = false, bool showTips = true)`、`LoadScene(Scenes sceneEnum)`、`LoadScene(SceneLoadingContext context)`、`LoadTarget(SceneLoadingContext context)`、`LoadBaseScene()`、`LoadMainMenu()`、`NotifyPointerClick()`。
+
+#### SceneLoadingContext 与 SceneLoadingEventsReceiver
+- `SceneLoadingContext` - 静态属性 `SceneLoadingContext`，存储当前加载上下文信息。
+- `SceneLoadingEventsReceiver` - 接收场景加载事件的挂件组件，通过 UnityEvent 配置回调（无额外公开方法）。
+
+#### GamePrepareProcess
+- 负责关卡启动前的准备流程，核心逻辑通过 Inspector 配置的步骤执行。
+
+#### GameClock
+- 静态属性：`Instance`、`TimeOfDay`、`Day`、`Now`、`Hour`、`Minut`、`Seconds`、`Milliseconds`、`RealTimePlayed`。
+- 事件：`OnGameClockStep` - 时间步进时回调。
+- 方法：`GetRealTimePlayedOfSaveSlot(int slotIndex)`、`StepTimeTil(TimeSpan targetTime)`。
+
+---
+
+### 环境与天气
+- `FogOfWarManager` - 提供战争迷雾渲染控制，公开字段用于配置渲染器、半径等（通过 Inspector 设置）。
+- `TimeOfDayController` - 静态属性 `Instance`，属性 `AtNight`、`CurrentPhase`、`CurrentWeather`、`Time`，方法：`GetTimePhaseNameByPhaseTag(string tag)`、`GetWeatherNameByWeather(TimeOfDayController.Weather weather)`。
+- `StormWeather` - 控制风暴天气特效与触发器，包含 `StartStorm()`、`StopStorm()` 等公开方法。
+
+---
+
+### AI、角色生成与声音
+
+#### AIMainBrain
+- 属性：`SearchTaskContext`、`CheckObsticleTaskContext`。
+- 静态事件：`OnSoundSpawned`、`OnPlayerHearSound`。
+- 方法：`MakeSound(AISound sound)`、`AddSearchTask(AIPathSearchTask task)`、`AddCheckObsticleTask(AIPathCheckTask task)`。
+
+#### AICharacterController
+- 属性：`CharacterMainControl`、`NoticeFromPos`、`NoticeFromDirection`、`NoticeFromCharacter`。
+- 方法：`Init(CharacterMainControl character)`、`NightReactionTimeMultiplier()`、`AddItemSkill(ItemAgent skill)`、`GetItemSkill(ItemAgent skill)`、`CheckAndAddDrugItem(Item item)`、`GetDrugItem()`、`SetNoticedToTarget(CharacterMainControl target)`、`IsHurt()`、`isNoticing()`、`MoveToPos(Vector3 position)`、`HasPath()`、`WaitingForPathResult()`、`StopMove()`、`IsMoving()`、`ReachedEndOfPath()`、`SetTarget(Transform target)`、`SetAimInput(Vector2 aim)`、`PutBackWeapon()`、`TakeOutWeapon()`。
+
+#### CharacterSpawner 体系
+- `CharacterSpawnerRoot` - 属性 `RelatedScene`，方法 `AddCreatedCharacter(CharacterMainControl character)`。
+- `CharacterSpawnerGroupSelector` - 负责随机选择分组生成，方法 `Collect()`、`RandomSpawn()`。
+- `CharacterSpawnerComponentBase` - 可扩展的基类（具体生成逻辑由子类实现）。
+
+---
+
+### 存档与玩家存储
+
+#### SavesSystem
+- 静态属性：`SavesSystem`、`CurrentSlot`、`CurrentFilePath`、`IsSaving`、`SavesFolder`、`RestoreFailureMarker`、`GlobalSaveDataFilePath`、`GlobalSaveDataFileName`、`BackupInfo`、`TimeValid`、`Time`。
+- 静态事件：`OnSetFile`、`OnSaveDeleted`、`OnCollectSaveData`、`OnRestoreFailureDetected`。
+- 主要方法：`GetFullPathToSavesFolder()`、`GetFilePath(int slot)`、`GetSaveFileName(int slot)`、`IsOldSave(string filePath)`、`SetFile(int slot)`、`GetBackupList(int slot)` / `GetBackupList(string path)` / `GetBackupList(DirectoryInfo dir)`、`UpgradeSaveFileAssemblyInfo()`、`RestoreIndexedBackup(int index)`、`GetSaveTimeUTC(string filePath)`、`GetSaveTimeLocal(string filePath)`、`SaveFile(int slot)`、`KeyExisits(string key)`（及重载）、`CollectSaveData()`、`IsOldGame(int slot)`（及重载）、`DeleteCurrentSave()`。
+
+#### PlayerStorage 与 Buffer
+- `PlayerStorage` 属性：`Instance`、`Inventory`、`IncomingItemBuffer`、`InteractableLootBox`、`DefaultCapacity`、`Loading`、`TakingItem`、`StorageCapacityCalculationHolder`。
+- 事件：`OnRecalculateStorageCapacity`、`OnTakeBufferItem`、`OnItemAddedToBuffer`、`OnLoadingFinished`。
+- 方法：`IsAccessableAndNotFull()`、`NotifyCapacityDirty()`、`Push(Item item)`、`RecalculateStorageCapacity()`、`TakeBufferItem()`、`HasInitialized()`。
+- `PlayerStorageBuffer` 属性：`Instance`、`Buffer`；方法：`SaveBuffer()`、`LoadBuffer()`。
+
+#### PlayerPositionBackupManager
+- 方法：`BackupCurrentPos()`、`StartRecover(float duration)`、`SetPlayerToBackupPos()`。
+
+---
+
+### 其他系统
+- `MultiInteraction`、`NotificationProxy`、`DialogueBubbleProxy` 等辅助组件用于交互提示与文本反馈。
+- `GameCamera`、`HUDManager` 与 `InputManager` 协同提供 UI 与操作体验。
+- `ModBehaviour` / `ModManager`（参见 Mod 模块）提供 Mod 生命周期入口。
 
 ## 使用示例
 
@@ -224,6 +787,12 @@ if (CraftingManager.IsFormulaUnlocked("Weapon_AK47"))
 }
 ```
 
+### 输入控制
+```csharp
+InputManager.SetInputDevice(InputManager.InputDevices.Gamepad);
+InputManager.OnSwitchWeaponInput += dir => Debug.Log($"切换武器方向: {dir}");
+```
+
 ### 生命值系统
 ```csharp
 Health health = GetComponent<Health>();
@@ -247,13 +816,13 @@ Health.OnDead += OnDead;
 
 ## 注意事项
 
-1. 所有静态属性在游戏未初始化时可能返回null，使用前请检查
-2. 事件订阅后记得在OnDisable中取消订阅，避免内存泄漏
-3. 角色相关操作需要在关卡初始化完成后进行
-4. Mod开发时请继承ModBehaviour基类并实现必要的方法
-5. 制作系统需要先解锁配方才能制作物品
-6. 输入管理器支持多种输入设备，需要根据设备类型处理输入
-7. 生命值系统的伤害计算包含护甲、暴击、元素抗性等复杂因素
-8. Buff系统与生命值系统紧密相关，受伤时可能触发Buff
-9. 制作配方的解锁状态会保存在存档中
-10. 输入设备切换时会触发相应事件，需要更新UI显示
+1. 静态属性在游戏未初始化时可能返回 `null`，使用前请判空。
+2. 事件订阅后记得在 `OnDisable` 中取消订阅，避免内存泄漏。
+3. 角色相关操作需要在关卡初始化完成后进行。
+4. Mod 开发时请继承 `ModBehaviour` 基类并实现必要的重写方法。
+5. 制作系统需要先解锁配方才能制作物品，内部将数据持久化到存档。
+6. 输入管理器支持多种输入设备，切换时会触发 `OnInputDeviceChanged` 以便更新 UI。
+7. 生命值系统与 Buff、护甲等多个组件耦合，伤害计算需考虑这些因素。
+8. Buff 系统与生命值系统紧密相关，受伤或死亡时可能触发 Buff。
+9. 制作配方的解锁状态会保存在存档中，`UnlockedFormulaIDs` 仅枚举已解锁条目。
+10. 关闭或启用输入时请成对调用 `DisableInput` 与 `ActiveInput`，否则可能导致输入被锁定。

--- a/docs/modules/itemstats.md
+++ b/docs/modules/itemstats.md
@@ -1,273 +1,203 @@
-# ItemStatsSystem - 物品统计系统
+# ItemStatsSystem 模块
 
-## 概述
-ItemStatsSystem 是《逃离鸭科夫》的物品统计系统，负责管理游戏中的所有物品、属性、效果、背包等功能。
+> 对应程序集：`ItemStatsSystem.dll`
 
-## 核心类
+ItemStatsSystem 承担 Duckov 物品、背包、统计与效果的全部运行时代码。下列内容按照职能对反编译程序集中的公开类型、枚举、事件与主要方法进行归档，帮助 Mod 开发者对照 API。
 
-### Item
-物品类，游戏中最基础的对象，所有物品都继承自此类。
+## 1. 核心物品与容器
 
-#### 属性
-- `TypeID` - 物品类型ID
-- `Order` - 排序
-- `DisplayName` - 显示名称
-- `DisplayNameRaw` - 原始显示名称
-- `Description` - 描述
-- `DescriptionRaw` - 原始描述
-- `Icon` - 图标
-- `MaxStackCount` - 最大堆叠数量
-- `Stackable` - 是否可堆叠
-- `Value` - 价值
-- `Quality` - 品质
-- `DisplayQuality` - 显示品质
-- `UnitSelfWeight` - 单位自身重量
-- `SelfWeight` - 自身重量
-- `Sticky` - 是否粘性（不可丢弃）
-- `CanBeSold` - 是否可出售
-- `CanDrop` - 是否可丢弃
-- `TotalWeight` - 总重量
-- `HasHandHeldAgent` - 是否有手持代理
-- `AgentUtilities` - 代理工具
-- `ActiveAgent` - 活动代理
-- `ItemGraphic` - 物品图形
-- `Stats` - 统计属性
-- `Modifiers` - 修饰符
-- `Slots` - 插槽
-- `Inventory` - 背包
-- `Effects` - 效果
-- `PluggedIntoSlot` - 插入的插槽
-- `InInventory` - 所在背包
-- `ParentItem` - 父物品
-- `ParentObject` - 父对象
-- `Tags` - 标签
-- `Variables` - 变量
-- `Constants` - 常量
-- `IsCharacter` - 是否是角色
-- `StackCount` - 堆叠数量
-- `UseDurability` - 是否使用耐久度
-- `MaxDurability` - 最大耐久度
-- `MaxDurabilityWithLoss` - 考虑损失的最大耐久度
-- `DurabilityLoss` - 耐久度损失
-- `Durability` - 当前耐久度
-- `Inspected` - 是否已检查
-- `Inspecting` - 是否正在检查
-- `NeedInspection` - 是否需要检查
-- `IsBeingDestroyed` - 是否正在被销毁
-- `Repairable` - 是否可修复
-- `SoundKey` - 声音键
+### `Item`
+- 继承 `MonoBehaviour`、实现 `ISelfValidator`，是所有物品的宿主组件。
+- **识别与展示**：`TypeID`（内部设定）、`Order`、`DisplayName`/`DisplayNameRaw`、`Description`/`DescriptionRaw`、`Icon`、`DisplayQuality`、`SoundKey`。
+- **重量与堆叠**：`UnitSelfWeight`、`SelfWeight`、`TotalWeight`（包含子物品）、`MaxStackCount`、`StackCount`、`Stackable`，提供 `SetStackCount`、`TryMergeStack`、`Combine`、`CombineInto`、`Split(int count)`（返回 `UniTask<Item>`）等操作。
+- **状态管理**：`Sticky`、`CanBeSold`、`CanDrop`、`IsCharacter`、`Repairable`、`UseDurability`、`Durability`/`MaxDurability`/`DurabilityLoss`、`NeedInspection`、`Inspected`、`Inspecting`、`IsBeingDestroyed` 等。
+- **组件引用**：
+  - `AgentUtilities` / `ActiveAgent`（代理系统）。
+  - `ItemGraphic`（`ItemGraphicInfo`）。
+  - `Stats` (`StatCollection`)、`Modifiers` (`ModifierDescriptionCollection`)、`Slots` (`SlotCollection`)、`Inventory`、`Effects` (`List<Effect>`)、`UsageUtilities`。
+  - 自定义数据：`Variables`、`Constants` (`List<CustomData>`)、`Tags` (`TagCollection`)。
+- **层级关系**：`ParentObject`、`ParentItem`、`PluggedIntoSlot`、`InInventory`、`IsAttached`、`GetAllChildren(includeInactive, includeSelf)`、`GetRootParent()`。
+- **交互方法**：`Use(object user)`（委托给 `UsageUtilities`）、`Detach()`、`NotifyAddedToInventory`/`NotifyRemovedFromInventory`、`PlugInto(Slot slot)`、`Unplug()`、`RecalculateTotalWeight()`、`RebuildAllComponents()`、`Inspect()`、`RequestInspection()`、`Repair(float delta)`、`NotifyUsed()`、`DestroySelf()` 等。
+- **事件**：`onItemTreeChanged`、`onDestroy`、`onSetStackCount`、`onDurabilityChanged`、`onInspectionStateChanged`、`onUse`、`onUseStatic`、`onChildChanged`、`onParentChanged`、`onPluggedIntoSlot`、`onUnpluggedFromSlot`、`onSlotContentChanged`、`onSlotTreeChanged`。
 
-#### 事件
-- `onItemTreeChanged` - 物品树改变事件
-- `onDestroy` - 销毁事件
-- `onSetStackCount` - 设置堆叠数量事件
-- `onDurabilityChanged` - 耐久度改变事件
-- `onInspectionStateChanged` - 检查状态改变事件
-- `onUse` - 使用事件
-- `onUseStatic` - 静态使用事件
-- `onChildChanged` - 子物品改变事件
-- `onParentChanged` - 父物品改变事件
-- `onPluggedIntoSlot` - 插入插槽事件
-- `onUnpluggedFromSlot` - 从插槽拔出事件
-- `onSlotContentChanged` - 插槽内容改变事件
-- `onSlotTreeChanged` - 插槽树改变事件
+### `Slot`
+- 表示装备/插件位，包含 `Key`、`DisplayName`/`Raw`、`Icon`、`Locked`、`Hidden`、`AutoEquip`、`CanDragOut`、`AllowedTypes` (`ItemFilter`) 等属性。
+- `Content` 指向当前物品，支持 `SetContent`、`ClearContent`、`CanInsert(Item candidate)`、`Initialize(SlotCollection owner)`。
+- 事件：`onSlotContentChanged`、`onSlotTreeChanged`。
 
-### ItemAssetsCollection
-物品资产集合，管理游戏中所有物品的预制体和元数据。
+### `SlotCollection`
+- `ItemComponent` 实现，维护 `Slot` 列表并实现 `ICollection<Slot>`。
+- 通过索引器或 `GetSlot(string key)` / `GetSlot(int hash)` 快速查找。
+- `OnInitialize` 会为所有插槽绑定宿主。
 
-#### 静态属性
-- `Instance` - 获取实例
+### `Inventory`
+- `MonoBehaviour` 容器，实现 `ISelfValidator` 与 `IEnumerable<Item>`。
+- **属性**：`DisplayNameKey`、`DisplayName`、`Capacity`、`Content`、`AttachedToItem`、`NeedInspection`、`AcceptSticky`、`Loading`、`CachedWeight`、`lockedIndexes`。
+- **事件**：`onContentChanged`、`onInventorySorted`、`onCapacityChanged`、`onSetIndexLock`。
+- **操作**：`AddItem`、`AddAt`、`RemoveItem`、`RemoveAt`、`GetItemAt`、`GetIndex`、`GetFirstEmptyPosition`、`GetLastItemPosition`、`Find(int typeID)`、`Sort()`（按标签/类型/堆叠自动整理）、`LockIndex`/`UnlockIndex`/`ToggleLockIndex`、`IsEmpty()`、`RecalculateWeight()`。
 
-#### 属性
-- `NextTypeID` - 下一个类型ID
+### `ItemGraphicInfo`
+- 存放展示资源：`DisplayPrefab`、`PreviewCameraOffset`、`PreviewRotation`、`PreviewScale` 等。
+- 提供 `GetRenderTexture`、`BakePreview()` 等生成缩略图的工具。
 
-#### 静态方法
-- `AddDynamicEntry(Item prefab)` - 添加动态条目
-- `RemoveDynamicEntry(Item prefab)` - 移除动态条目
-- `InstantiateAsync(int typeID)` - 异步实例化物品
-- `InstantiateSync(int typeID)` - 同步实例化物品
-- `GetMetaData(int typeID)` - 获取元数据
-- `GetPrefab(int typeID)` - 获取预制体
-- `GetAllTypeIds(ItemFilter filter)` - 获取所有类型ID
-- `Search(ItemFilter filter)` - 搜索物品
-- `TryGetIDByName(string name)` - 尝试通过名称获取ID
+### 其他基础组件
+- `ItemComponent`：所有子组件基类，持有 `Master` (`Item`)、`Display`、`DisplayName`，在 `Validate` 中确保与宿主 Item 同对象。
+- `ItemAgent`：代理实体，`Initialize(Item, AgentTypes)` 绑定宿主并监听 `onUnpluggedFromSlot`；代理类型包括 `normal`、`pickUp`、`handheld`、`equipment`。
+- `ItemAgentUtilities`：序列化的代理库，依据 key/hash 创建代理（`CreateAgent`）、`ReleaseActiveAgent`，并通过 `onCreateAgent` 事件暴露创建回调。
+- `ItemTreeExtensions`：扩展方法集合（如 `IsInCharacterSlot`、`GetRootParent`、`GetAllChildren`）。
 
-### Inventory
-背包类，管理物品的存储和检索。
+## 2. 统计与修饰
 
-#### 属性
-- `Capacity` - 容量
-- `Content` - 内容列表
-- `Loading` - 是否正在加载
-- `AttachedToItem` - 附加到的物品
-- `NeedInspection` - 是否需要检查
-- `CachedWeight` - 缓存重量
+### `StatCollection`
+- 附加于 Item 的属性集，实现 `IEnumerable<Stat>`。
+- 方法：`Initialize(Item master)`、`Add(Stat stat)`、`Remove(string key)`、`GetStat(string key)`、`Contains(string key)`、`RecalculateAll()`。
+- 事件：`onSetDirty`（内部 `Stat` 触发时级联）。
 
-#### 事件
-- `onContentChanged` - 内容改变事件
+### `Stat`
+- 单个数值条目，公开 `Key`、`DisplayNameKey`、`DisplayName`、`BaseValue`、`Value`、`Display`、`Modifiers`。
+- 方法：`AddModifier(Modifier)`、`RemoveModifier(Modifier)`、`ClearModifiers()`、`Recalculate()`。
+- `OnSetDirty` 事件在属性需要刷新时触发。
 
-#### 方法
-- `AddItem(Item item)` - 添加物品
-- `RemoveItem(Item item)` - 移除物品
-- `AddAndMerge(Item item, int index)` - 添加并合并
-- `SetCapacity(int capacity)` - 设置容量
-- `RecalculateWeight()` - 重新计算重量
-- `NotifyContentChanged(Item item)` - 通知内容改变
+### `ModifierDescriptionCollection`
+- `ItemComponent`，序列化 `ModifierDescription` 列表并在 `OnInitialize` 中应用。
+- 提供 `ReapplyModifiers()`、`Add(ModifierDescription)`、`Remove(ModifierDescription)`、`Clear()`、`GetDescription(string key)`。
 
-### Slot
-插槽类，用于物品的装备和连接。
+### `ModifierDescription`
+- 定义单个修饰：`Key`、`Type` (`ModifierType`)、`Value`、`Order`、`ModifierTarget`、`Display`、`Polarity`、`enableInInventory`、`overrideOrder`。
+- 方法：`CreateModifier(object source)`、`ReapplyModifier(ModifierDescriptionCollection)`、`RemoveModifier()`、`GetTargetItem()`、`GetDescription()`。
 
-#### 属性
-- `Key` - 键
-- `Content` - 内容
-- `Master` - 主物品
-- `Hash` - 哈希值
+### 辅助枚举与结构
+- `ModifierTarget`（`Self`、`Parent`、`Children`、`Character`）。
+- `ModifierType`（定义在 `ItemStatsSystem.Stats` 命名空间）。
+- `Polarity`（`Negative`、`Neutral`、`Positive`）。
+- `ModifierDescriptionCollection.ModifierMeta`：在编辑器中描述修饰顺序与显示开关。
 
-#### 方法
-- `Plug(Item item)` - 插入物品
-- `Unplug()` - 拔出物品
-- `ForceInvokeSlotContentChangedEvent()` - 强制触发插槽内容改变事件
+## 3. 效果系统
 
-### Stat
-统计属性类，管理物品的各种数值属性。
+### `Effect`
+- 聚合效果逻辑的核心组件，持有 `Item`、`Display`、`Description`。
+- 公开只读集合 `Triggers`、`Filters`、`Actions`。
+- 事件：`onSetTargetItem`、`onItemTreeChanged`。
+- 方法：`AddEffectComponent(EffectComponent)`、`RemoveEffectComponent`、`SetItem(Item target)`、`Trigger(EffectTriggerEventContext context)`。
 
-#### 属性
-- `Key` - 键
-- `BaseValue` - 基础值
-- `Value` - 当前值
-- `Modifiers` - 修饰符列表
+### `EffectComponent`
+- `Effect` 子元素基类，提供 `Master`、`DisplayName`、`LabelColor`、`Validate(SelfValidationResult)`。
+- `Effect` 在运行时会为每个子组件调用 `OnAttachToMaster`/`OnDetachFromMaster`（在派生类实现）。
 
-#### 方法
-- `AddModifier(Modifier modifier)` - 添加修饰符
-- `RemoveModifier(Modifier modifier)` - 移除修饰符
-- `RemoveAllModifiersFromSource(object source)` - 移除来自指定源的所有修饰符
+### 触发器
+- `EffectTrigger`：通过 `Trigger(bool positive)`/`TriggerPositive()`/`TriggerNegative()` 将事件发送给 `Effect`，在 `OnDisable` 时默认触发负向。
+- `UpdateTrigger`：按帧或固定间隔触发（`useFixedUpdate`、`interval`）。
+- `TickTrigger`：基于 `tickRate` 定时，支持 `useUnscaledTime`。
+- `ItemUsedTrigger`：监听 `Item.onUse`。
+- `TriggerOnSetItem`：当 `Effect` 的目标 Item 被设置时触发。
 
-### Modifier
-修饰符类，用于修改统计属性的值。
+### 过滤器
+- `EffectFilter`：实现 `Evaluate(EffectTriggerEventContext)`，并可忽略负向触发 (`IgnoreNegativeTrigger`)。
+- `BoolFilter`：内部布尔值控制效果是否通过。
+- `ItemInCharacterSlotFilter`：判定 `Effect.Item` 是否处于角色槽位。
 
-#### 属性
-- `Value` - 值
-- `Type` - 类型
-- `Source` - 源
+### 行为
+- `EffectAction`：接收触发通知并调用 `OnTriggered(bool positive)`、`OnTriggeredPositive()`、`OnTriggeredNegative()`。
+- `LogItemNameAction`、`LogWhenUsed`：调试用实现，输出触发信息。
 
-### Effect
-效果类，物品的被动效果。
+### 使用行为
+- `UsageBehavior`：抽象类，定义 `CanBeUsed(Item item, object user)` 与 `Use(Item item, object user)` 流程，`DisplaySettings` 可在 UI 中展示操作说明。
+- `UsageUtilities`：`ItemComponent`，维护 `behaviors` 列表、`UseTime`、耐久消耗、音效键，并暴露 `IsUsable(Item item, object user)`、`Use(Item item, object user)`；触发静态事件 `OnItemUsedStaticEvent`。
 
-#### 属性
-- `Item` - 关联的物品
+### 触发上下文
+- `EffectTriggerEventContext`：结构体，包含触发器引用 `source` 与正负向标记 `positive`。
 
-#### 方法
-- `SetItem(Item item)` - 设置关联物品
+## 4. 过滤与查询
 
-## 使用示例
+### `ItemFilter`
+- 支持嵌套、按类型 ID、标签、品质、极性、布尔开关等条件过滤。
+- 方法：`Evaluate(Item item)`、`Match(ItemMetaData meta)`、`CheckItemType(int typeId)`、`AddChild(ItemFilter child)`、`RemoveChild`。
+- 属性：`includeChildren`、`typeIDs`、`displayQualityRequirement`、`requiredTags`、`polarityRequirement` 等。
 
-### 创建物品实例
+### `BoolFilter`
+- 简单布尔开关，可单独使用或作为 `ItemFilter`、`EffectFilter` 的一部分。
+
+### `ItemInCharacterSlotFilter`
+- 检测指定 Item 是否装备在角色身上（或其父级是角色装备），常与效果系统结合。
+
+## 5. 序列化与数据交换
+
+### `ItemTreeData`
+- 用于序列化物品树。
+- 静态成员：`OnItemLoaded` 事件、`FromItem(Item item)`、`InstantiateAsync(ItemTreeData data)`、`InstantiateSync(ItemTreeData data)`。
+- 实例成员：`entries`、`rootInstanceID`、`RootData`、`RootTypeID`、`GetEntry(int instanceID)`、`ToString()`（打印树形结构）。
+- 内部类型：
+  - `DataEntry`（`instanceID`、`typeID`、`variables`、`slotContents`、`inventory`、`inventorySortLocks`、`TypeName`、`StackCount`）。
+  - `InventoryDataEntry`（索引 + 子实例 ID）。
+  - `SlotInstanceIDPair`（槽键 + 子实例 ID）。
+
+### `InventoryData`
+- 线性背包存档：`capacity`、`entries`、`lockedIndexes`。
+- 静态方法：`FromInventory(Inventory inventory)`、`LoadIntoInventory(InventoryData data, Inventory inventoryInstance)`（返回 `UniTask`）。
+- 内部 `Entry` 存储 `inventoryPosition` 与子树数据。
+
+## 6. 属性、标签与工具
+
+- `DisplayQuality`：枚举 `None`、`White`、`Green`、`Blue`、`Purple`、`Orange`、`Red`、`Q7`、`Q8`。
+- `ItemTypeIDAttribute` / `MenuPathAttribute`：Odin Inspector 支持，用于自定义菜单与类型标识。
+- `ModifierDescriptionCollection.ModifierMeta`、`ItemAgentUtilities.AgentKeyPair`、`StringLists`（来自 Utilities 模块）为编辑器下拉与键值提供支持。
+- `UnitySourceGeneratedAssemblyMonoScriptTypes_v1`：Unity 生成的脚本索引，无需在运行时代码中直接使用。
+
+## 7. 使用示例
+
+### 7.1 注册自定义使用行为
 ```csharp
-// 异步创建
-Item item = await ItemAssetsCollection.InstantiateAsync(typeID);
-
-// 同步创建
-Item item = ItemAssetsCollection.InstantiateSync(typeID);
-```
-
-### 获取物品属性
-```csharp
-Item item = GetItem();
-float weight = item.TotalWeight;
-int value = item.GetTotalRawValue();
-bool canSell = item.CanBeSold;
-```
-
-### 设置物品变量
-```csharp
-Item item = GetItem();
-item.SetFloat("CustomValue", 10.5f);
-item.SetInt("CustomCount", 5);
-item.SetBool("CustomFlag", true);
-item.SetString("CustomText", "Hello");
-```
-
-### 获取物品变量
-```csharp
-Item item = GetItem();
-float customValue = item.GetFloat("CustomValue", 0f);
-int customCount = item.GetInt("CustomCount", 0);
-bool customFlag = item.GetBool("CustomFlag", false);
-string customText = item.GetString("CustomText", "");
-```
-
-### 监听物品事件
-```csharp
-void OnEnable()
+public class HealUsage : UsageBehavior
 {
-    Item.onUseStatic += OnItemUsed;
+    public float healAmount = 25f;
+
+    public override bool CanBeUsed(Item item, object user)
+    {
+        return item.Durability > 0 && user is Health health && !health.IsDead;
+    }
+
+    protected override void OnUse(Item item, object user)
+    {
+        if (user is Health health)
+        {
+            health.Restore(healAmount);
+        }
+    }
 }
 
-void OnDisable()
+// 安装
+var usage = item.UsageUtilities;
+usage.behaviors.Add(item.gameObject.AddComponent<HealUsage>());
+```
+
+### 7.2 保存与恢复背包
+```csharp
+InventoryData snapshot = InventoryData.FromInventory(player.Backpack);
+await InventoryData.LoadIntoInventory(snapshot, player.Backpack);
+```
+
+### 7.3 按条件触发效果
+```csharp
+public class CriticalHitTrigger : EffectTrigger
 {
-    Item.onUseStatic -= OnItemUsed;
+    public void OnCriticalHit()
+    {
+        TriggerPositive();
+    }
 }
 
-private void OnItemUsed(Item item, object user)
+public class CriticalBonusAction : EffectAction
 {
-    Debug.Log($"物品 {item.DisplayName} 被 {user} 使用");
+    protected override void OnTriggeredPositive()
+    {
+        Master.Item.Stats.GetStat("CritBonus")?.AddModifier(new Modifier(ModifierType.Add, 0.1f, source: this));
+    }
+
+    protected override void OnTriggeredNegative()
+    {
+        // 触发器关闭时清除
+    }
 }
 ```
 
-### 添加动态物品
-```csharp
-// 添加自定义物品到游戏中
-Item customItem = CreateCustomItem();
-bool success = ItemAssetsCollection.AddDynamicEntry(customItem);
-
-// 移除自定义物品
-ItemAssetsCollection.RemoveDynamicEntry(customItem);
-```
-
-### 搜索物品
-```csharp
-ItemFilter filter = new ItemFilter();
-filter.tags = new string[] { "Weapon" };
-filter.minQuality = 1;
-filter.maxQuality = 5;
-
-int[] itemIds = ItemAssetsCollection.Search(filter);
-```
-
-### 物品合并和分割
-```csharp
-Item item1 = GetItem();
-Item item2 = GetItem();
-
-// 合并物品
-item1.Combine(item2);
-
-// 分割物品
-Item splitItem = await item1.Split(5);
-```
-
-### 获取物品统计属性
-```csharp
-Item item = GetItem();
-Stat damageStat = item.GetStat("Damage");
-if (damageStat != null)
-{
-    float damage = damageStat.Value;
-}
-
-// 或者直接获取值
-float damage = item.GetStatValue("Damage");
-```
-
-## 注意事项
-
-1. 物品的TypeID必须唯一，避免冲突
-2. 动态添加的物品在游戏重启后会丢失，需要重新添加
-3. 物品的堆叠数量不能超过MaxStackCount
-4. 使用物品前请检查IsUsable方法
-5. 物品的耐久度为0时，某些效果可能不会生效
-6. 物品的标签用于分类和过滤，请合理使用
-7. 自定义变量会保存在存档中，请谨慎使用
-8. 物品的父级关系会影响其效果和重量计算
-9. 统计属性的修饰符按顺序计算，顺序很重要
-10. 物品代理的生命周期与物品绑定，物品销毁时代理也会销毁
+借助上述归档，Mod 作者可以快速对照 ItemStatsSystem 的运行时代码，覆盖物品、插槽、背包、统计、修饰、效果、使用逻辑与序列化的全部 API。

--- a/docs/modules/utilities.md
+++ b/docs/modules/utilities.md
@@ -95,6 +95,90 @@ TeamSoda.Duckov.Utilities 是《逃离鸭科夫》游戏的工具模块，提供
 - `Find(Predicate<T> predicate)` - 查找对象
 - `ReleaseAll(Predicate<T> predicate)` - 释放符合条件的对象
 
+### IPoolable
+对象池条目接口，在进入或离开池时获得通知。
+
+#### 方法
+- `NotifyPooled()` - 当对象被回收到池时触发，适合重置状态。
+- `NotifyReleased()` - 当对象从池中取出时触发，可进行激活初始化。
+
+### UpdatableInvoker 与 IUpdatable
+帧更新调度器，将实现 `IUpdatable` 的对象集中驱动。
+
+#### UpdatableInvoker
+- `Instance` *(static)* - 单例访问器，必要时会自动创建隐藏对象。
+- `Register(IUpdatable updatable)` - 注册等待逐帧执行的逻辑。
+- `Unregister(IUpdatable updatable)` - 取消注册，避免继续调用。
+- 内部 `Update()` 时会调用所有已注册对象的 `OnUpdate()`。
+
+#### IUpdatable
+- `OnUpdate()` - 逐帧更新回调接口。
+
+### RandomUtilities
+集合随机工具扩展，封装常用随机化逻辑。
+
+#### 常用方法
+- `RandomizeOrder<T>(this List<T> list)` - 原地打乱列表顺序。
+- `GetRandom<T>(this IList<T> list)` *(含 `System.Random` 重载)* - 获取随机元素。
+- `GetRandomSubSet<T>(this IList<T> list, int amount)` - 获取随机子集。
+- `GetRandom<T>(this T[] array)` - 从数组中随机返回一个元素。
+- `GetRandomWeighted<T>(this IList<T> list, Func<T, float> weightFunction, float lowPercent = 0f)` - 按权重随机。
+
+### RandomContainer<T>
+可序列化的权重随机容器。
+
+#### 属性
+- `Count` - 当前条目数量。
+
+#### 方法
+- `AddEntry(T value, float weight)` - 添加带权重的候选。
+- `GetRandom(float lowPercent = 0f)` - 按权重随机返回结果。
+- `GetRandom(System.Random overrideRandom, float lowPercent = 0f)` - 使用指定随机源。
+- `GetRandom(System.Random overrideRandom, Func<T, bool> predicator, float lowPercent = 0f)` - 在筛选条件后再随机。
+- `GetRandomMultiple(int count, bool repeatable = true)` - 获取多个随机结果，可设置是否允许重复。
+- `RefreshPercent()` - 重新计算每个条目的百分比说明（实现 `IPercentRefreshable`）。
+- `FromString(string str)` *(static)* - 解析形如 `Value:Weight` 的配置字符串构建容器。
+
+### Tag 与 TagCollection
+用于在物品或角色上应用标签并进行筛选。
+
+#### Tag
+- `Show` / `ShowDescription` - 控制是否在 UI 展示名称与描述。
+- `Priority` - 标签排序优先级。
+- `DisplayName` / `Description` - 本地化后的显示文本。
+- `Hash` - 标签哈希值。
+- `Color` - 标签显示颜色。
+- `Match(Tag tag, string name)` *(static)* - 比较名称是否对应标签。
+
+#### TagCollection
+- `Count` / `IsReadOnly` - 集合信息。
+- `Add(Tag tag)` / `Remove(Tag tag)` / `Clear()` - 集合操作。
+- `Contains(Tag tag)` / `Contains(string tagName)` - 检查标签是否存在。
+- `Check(ICollection<Tag> requireTags, ICollection<Tag> excludeTags)` - 依赖/排除检查，用于条件判断。
+- `Get(int index)` - 通过索引获取标签。
+
+### StringList 与 StringLists
+文本 ScriptableObject 集合，统一维护常量字符串。
+
+#### StringList
+- `Strings` - 只读字符串列表，可 `foreach` 遍历。
+
+#### StringLists
+- `StatKeys` / `SlotNames` / `ItemAgentKeys` *(static)* - 默认资源中预设的字符串集合。
+- 通过 `Resources.Load("DefaultStringLists")` 延迟加载。
+
+### DuckovUtilitiesSettings
+模块级配置 ScriptableObject。
+
+#### 静态属性
+- `Colors` - 返回 `ColorsData`（包含 `EffectTrigger`、`EffectFilter`、`EffectAction` 三种颜色配置）。
+
+### TrasnformExtensions
+Transform 辅助扩展。
+
+#### 方法
+- `DestroyAllChildren(this Transform transform)` - 清空并销毁所有子对象（编辑器下使用 `DestroyImmediate`）。
+
 ## 重要枚举
 
 ### CustomDataType


### PR DESCRIPTION
## Summary
- overhaul the ItemStatsSystem module document to catalogue items, containers, stats, effects, filters, data serialization, and usage patterns from the decompiled assembly
- expand the MiniLocalizor module guide with constructor behavior, dictionary rebuilding, DataEntry metadata, and integration tips

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68fb42de2c34832d80b9c1da633f8443